### PR TITLE
Windows Build Scripts

### DIFF
--- a/.github/workflows/build-windows-cli-only.yml
+++ b/.github/workflows/build-windows-cli-only.yml
@@ -1,4 +1,4 @@
-name: Build Installer - Windows 10
+name: Build CLI-Only Client - Windows 10
 
 on:
   workflow_dispatch:
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   build:
-    name: Windows 10 Installer
+    name: Windows 10 CLI Binaries
     runs-on: [windows-2019]
     timeout-minutes: 50
     strategy:
@@ -29,19 +29,6 @@ jobs:
       run: |
         git config --global url."https://github.com/".insteadOf ssh://git@github.com/
 
-    - name: Get npm cache directory
-      id: npm-cache
-      run: |
-        echo "::set-output name=dir::$(npm config get cache)"
-
-    - name: Cache npm
-      uses: actions/cache@v3
-      with:
-        path: ${{ steps.npm-cache.outputs.dir }}
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
-
     - name: Get pip cache dir
       id: pip-cache
       run: |
@@ -59,29 +46,6 @@ jobs:
       name: Install Python ${{ matrix.python-version }}
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Setup Node 16.x
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16.x'
-
-    - name: Test for secrets access
-      id: check_secrets
-      shell: bash
-      run: |
-        unset HAS_SIGNING_SECRET
-
-        if [ -n "$SIGNING_SECRET" ]; then HAS_SIGNING_SECRET='true' ; fi
-        echo "::set-output name=HAS_SIGNING_SECRET::${HAS_SIGNING_SECRET}"
-      env:
-        SIGNING_SECRET: "${{ secrets.WIN_CODE_SIGN_CERT }}"
-
-    - name: Decode code signing cert into an encrypted file
-      if: steps.check_secrets.outputs.HAS_SIGNING_SECRET
-      uses: kitek/decode-base64-into-file-action@1.0
-      with:
-        encoded-value: ${{ secrets.WIN_CODE_SIGN_CERT }}
-        destination-file: .\lotus-blockchain-gui\win_code_sign_cert.p12
 
     # Create our own venv outside of the git directory JUST for getting the ACTUAL version so that install can't break it
     - name: Get version number
@@ -142,9 +106,7 @@ jobs:
 
     - name: Build Windows installer with build_scripts\build_windows.ps1
       env:
-        CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
         WIN_CODE_SIGN_PASS: ${{ secrets.WIN_CODE_SIGN_PASS }}
-        HAS_SECRET: ${{ steps.check_secrets.outputs.HAS_SIGNING_SECRET }}
       run: |
         $env:path="C:\Program` Files` (x86)\Microsoft` Visual` Studio\2019\Enterprise\SDK\ScopeCppSDK\vc15\VC\bin\;$env:path"
         $env:path="C:\Program` Files` (x86)\Windows` Kits\10\App` Certification` Kit;$env:path"
@@ -157,20 +119,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: Windows-Exe
-        path: ${{ github.workspace }}\lotus-blockchain-gui\Lotus-win32-x64\
-
-    - name: Upload Installer to artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: lotus-installers-windows-exe-intel
-        path: ${{ github.workspace }}\lotus-blockchain-gui\release-builds\
-
-    - name: Create Checksums
-      env:
-        CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
-      run: |
-         certutil.exe -hashfile ${{ github.workspace }}\lotus-blockchain-gui\release-builds\windows-installer\LotusSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe SHA256 > ${{ github.workspace }}\lotus-blockchain-gui\release-builds\windows-installer\LotusSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe.sha256
-         ls ${{ github.workspace }}\lotus-blockchain-gui\release-builds\windows-installer\
+        path: ${{ github.workspace }}\Lotus-win32-x64\
 
     - name: Get tag name
       if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build-windows-cli-only.yml
+++ b/.github/workflows/build-windows-cli-only.yml
@@ -54,9 +54,9 @@ jobs:
         python -m venv ..\venv
         . ..\venv\Scripts\Activate.ps1
         pip3 install setuptools_scm
-        $env:CHIA_INSTALLER_VERSION = python .\build_scripts\installer-version.py -win
-        echo "$env:CHIA_INSTALLER_VERSION"
-        echo "::set-output name=CHIA_INSTALLER_VERSION::$env:CHIA_INSTALLER_VERSION"
+        $env:LOTUS_INSTALLER_VERSION = python .\build_scripts\installer-version.py -win
+        echo "$env:LOTUS_INSTALLER_VERSION"
+        echo "::set-output name=LOTUS_INSTALLER_VERSION::$env:LOTUS_INSTALLER_VERSION"
         deactivate
 
       # Get the most recent release from chia-plotter-madmax

--- a/.github/workflows/build-windows-cli-only.yml
+++ b/.github/workflows/build-windows-cli-only.yml
@@ -54,9 +54,9 @@ jobs:
         python -m venv ..\venv
         . ..\venv\Scripts\Activate.ps1
         pip3 install setuptools_scm
-        $env:LOTUS_INSTALLER_VERSION = python .\build_scripts\installer-version.py -win
-        echo "$env:LOTUS_INSTALLER_VERSION"
-        echo "::set-output name=LOTUS_INSTALLER_VERSION::$env:LOTUS_INSTALLER_VERSION"
+        $env:LOTUS_VERSION = python .\build_scripts\installer-version.py -win
+        echo "$env:LOTUS_VERSION"
+        echo "::set-output name=LOTUS_VERSION::$env:LOTUS_VERSION"
         deactivate
 
       # Get the most recent release from chia-plotter-madmax

--- a/.github/workflows/build-windows-cli-only.yml
+++ b/.github/workflows/build-windows-cli-only.yml
@@ -104,7 +104,7 @@ jobs:
       run: |
         .\Install.ps1 -d
 
-    - name: Build Windows installer with build_scripts\build_windows.ps1
+    - name: Build Windows binaries with build_scripts\build_windows.ps1
       env:
         WIN_CODE_SIGN_PASS: ${{ secrets.WIN_CODE_SIGN_PASS }}
       run: |

--- a/.github/workflows/build-windows-cli-only.yml
+++ b/.github/workflows/build-windows-cli-only.yml
@@ -106,7 +106,7 @@ jobs:
 
     - name: Build Windows binaries with build_scripts\build_windows.ps1
       env:
-        WIN_CODE_SIGN_PASS: ${{ secrets.WIN_CODE_SIGN_PASS }}
+        LOTUS_VERSION: ${{ steps.version_number.outputs.LOTUS_VERSION }}
       run: |
         $env:path="C:\Program` Files` (x86)\Microsoft` Visual` Studio\2019\Enterprise\SDK\ScopeCppSDK\vc15\VC\bin\;$env:path"
         $env:path="C:\Program` Files` (x86)\Windows` Kits\10\App` Certification` Kit;$env:path"

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -1,16 +1,7 @@
 name: Build Installer - Windows 10
 
 on:
-  push:
-    branches:
-      - 'long_lived/**'
-      - main
-      - 'release/**'
-    tags:
-        - '**'
-  pull_request:
-    branches:
-      - '**'
+  workflow_dispatch:
 
 concurrency:
   # SHA is added to the end if on `main` to let all main workflows run
@@ -79,13 +70,9 @@ jobs:
       shell: bash
       run: |
         unset HAS_SIGNING_SECRET
-        unset HAS_AWS_SECRET
 
         if [ -n "$SIGNING_SECRET" ]; then HAS_SIGNING_SECRET='true' ; fi
         echo "::set-output name=HAS_SIGNING_SECRET::${HAS_SIGNING_SECRET}"
-
-        if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
-        echo ::set-output name=HAS_AWS_SECRET::${HAS_AWS_SECRET}
       env:
         SIGNING_SECRET: "${{ secrets.WIN_CODE_SIGN_CERT }}"
         AWS_SECRET: "${{ secrets.INSTALLER_UPLOAD_KEY }}"
@@ -179,67 +166,12 @@ jobs:
         name: chia-installers-windows-exe-intel
         path: ${{ github.workspace }}\chia-blockchain-gui\release-builds\
 
-    - name: Install AWS CLI
-      if: steps.check_secrets.outputs.HAS_AWS_SECRET
-      run: |
-          msiexec.exe /i https://awscli.amazonaws.com/AWSCLIV2.msi
-
-    - name: Configure AWS Credentials
-      if: steps.check_secrets.outputs.HAS_AWS_SECRET
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.INSTALLER_UPLOAD_KEY }}
-        aws-secret-access-key: ${{ secrets.INSTALLER_UPLOAD_SECRET }}
-        aws-region: us-west-2
-
-    - name: Upload to s3
-      if: steps.check_secrets.outputs.HAS_AWS_SECRET
-      env:
-        CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
-      shell: bash
-      run: |
-        GIT_SHORT_HASH=$(echo "${GITHUB_SHA}" | cut -c1-8)
-        CHIA_DEV_BUILD=${CHIA_INSTALLER_VERSION}-$GIT_SHORT_HASH
-        echo ::set-output name=CHIA_DEV_BUILD::${CHIA_DEV_BUILD}
-        echo ${CHIA_DEV_BUILD}
-        pwd
-        aws s3 cp chia-blockchain-gui/release-builds/windows-installer/ChiaSetup-${CHIA_INSTALLER_VERSION}.exe s3://download.chia.net/dev/ChiaSetup-${CHIA_DEV_BUILD}.exe
-
     - name: Create Checksums
       env:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
          certutil.exe -hashfile ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe SHA256 > ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe.sha256
          ls ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\
-
-    - name: Install py3createtorrent
-      if: startsWith(github.ref, 'refs/tags/')
-      run: |
-        pip3 install py3createtorrent
-
-    - name: Create torrent
-      if: startsWith(github.ref, 'refs/tags/')
-      run: |
-        py3createtorrent -f -t udp://tracker.opentrackr.org:1337/announce ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe -o ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe.torrent --webseed https://download.chia.net/install/ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe
-        ls
-
-    - name: Upload Beta Installer
-      if: steps.check_secrets.outputs.HAS_AWS_SECRET && github.ref == 'refs/heads/main'
-      env:
-        CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
-      run: |
-        aws s3 cp ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe s3://download.chia.net/beta/ChiaSetup-latest-beta.exe
-        aws s3 cp ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe.sha256 s3://download.chia.net/beta/ChiaSetup-latest-beta.exe.sha256
-
-    - name: Upload Release Files
-      if: steps.check_secrets.outputs.HAS_AWS_SECRET && startsWith(github.ref, 'refs/tags/')
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.INSTALLER_UPLOAD_KEY }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.INSTALLER_UPLOAD_SECRET }}
-      run: |
-        aws s3 cp ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe s3://download.chia.net/install/
-        aws s3 cp ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe.sha256 s3://download.chia.net/install/
-        aws s3 cp ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe.torrent s3://download.chia.net/torrents/
 
     - name: Get tag name
       if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -1,0 +1,261 @@
+name: Build Installer - Windows 10
+
+on:
+  push:
+    branches:
+      - 'long_lived/**'
+      - main
+      - 'release/**'
+    tags:
+        - '**'
+  pull_request:
+    branches:
+      - '**'
+
+concurrency:
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/long_lived/')) && github.sha || '' }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Windows 10 Installer
+    runs-on: [windows-2019]
+    timeout-minutes: 50
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.9]
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: recursive
+
+    - name: Set git urls to https instead of ssh
+      run: |
+        git config --global url."https://github.com/".insteadOf ssh://git@github.com/
+
+    - name: Get npm cache directory
+      id: npm-cache
+      run: |
+        echo "::set-output name=dir::$(npm config get cache)"
+
+    - name: Cache npm
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.npm-cache.outputs.dir }}
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        echo "::set-output name=dir::$(pip cache dir)"
+
+    - name: Cache pip
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - uses: actions/setup-python@v3
+      name: Install Python ${{ matrix.python-version }}
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Setup Node 16.x
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
+
+    - name: Test for secrets access
+      id: check_secrets
+      shell: bash
+      run: |
+        unset HAS_SIGNING_SECRET
+        unset HAS_AWS_SECRET
+
+        if [ -n "$SIGNING_SECRET" ]; then HAS_SIGNING_SECRET='true' ; fi
+        echo "::set-output name=HAS_SIGNING_SECRET::${HAS_SIGNING_SECRET}"
+
+        if [ -n "$AWS_SECRET" ]; then HAS_AWS_SECRET='true' ; fi
+        echo ::set-output name=HAS_AWS_SECRET::${HAS_AWS_SECRET}
+      env:
+        SIGNING_SECRET: "${{ secrets.WIN_CODE_SIGN_CERT }}"
+        AWS_SECRET: "${{ secrets.INSTALLER_UPLOAD_KEY }}"
+
+    - name: Decode code signing cert into an encrypted file
+      if: steps.check_secrets.outputs.HAS_SIGNING_SECRET
+      uses: kitek/decode-base64-into-file-action@1.0
+      with:
+        encoded-value: ${{ secrets.WIN_CODE_SIGN_CERT }}
+        destination-file: .\chia-blockchain-gui\win_code_sign_cert.p12
+
+    # Create our own venv outside of the git directory JUST for getting the ACTUAL version so that install can't break it
+    - name: Get version number
+      id: version_number
+      run: |
+        python -m venv ..\venv
+        . ..\venv\Scripts\Activate.ps1
+        pip3 install setuptools_scm
+        $env:CHIA_INSTALLER_VERSION = python .\build_scripts\installer-version.py -win
+        echo "$env:CHIA_INSTALLER_VERSION"
+        echo "::set-output name=CHIA_INSTALLER_VERSION::$env:CHIA_INSTALLER_VERSION"
+        deactivate
+
+      # Get the most recent release from chia-plotter-madmax
+    - uses: actions/github-script@v6
+      id: 'latest-madmax'
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        result-encoding: string
+        script: |
+          const release = await github.rest.repos.getLatestRelease({
+            owner: 'Chia-Network',
+            repo: 'chia-plotter-madmax',
+          });
+          return release.data.tag_name;
+
+    - name: Get latest madmax plotter
+      run: |
+        mkdir "$env:GITHUB_WORKSPACE\madmax"
+        Invoke-WebRequest https://github.com/Chia-Network/chia-plotter-madmax/releases/download/${{ steps.latest-madmax.outputs.result }}/chia_plot-${{ steps.latest-madmax.outputs.result }}.exe -OutFile "$env:GITHUB_WORKSPACE\madmax\chia_plot.exe"
+        Invoke-WebRequest https://github.com/Chia-Network/chia-plotter-madmax/releases/download/${{ steps.latest-madmax.outputs.result }}/chia_plot_k34-${{ steps.latest-madmax.outputs.result }}.exe -OutFile "$env:GITHUB_WORKSPACE\madmax\chia_plot_k34.exe"
+
+      # Get the most recent release from bladebit
+    - uses: actions/github-script@v6
+      id: 'latest-bladebit'
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        result-encoding: string
+        script: |
+          const release = await github.rest.repos.getLatestRelease({
+            owner: 'Chia-Network',
+            repo: 'bladebit',
+          });
+          return release.data.tag_name;
+
+    - name: Get latest bladebit plotter
+      run: |
+        mkdir "$env:GITHUB_WORKSPACE\bladebit"
+        Invoke-WebRequest https://github.com/Chia-Network/bladebit/releases/download/${{ steps.latest-bladebit.outputs.result }}/bladebit-${{ steps.latest-bladebit.outputs.result }}-windows-x86-64.zip -OutFile "$env:GITHUB_WORKSPACE\bladebit\bladebit.zip"
+        Expand-Archive -Path "$env:GITHUB_WORKSPACE\bladebit\bladebit.zip" -DestinationPath "$env:GITHUB_WORKSPACE\bladebit\"
+        rm "$env:GITHUB_WORKSPACE\bladebit\bladebit.zip"
+
+    - name: Run install script
+      env:
+        INSTALL_PYTHON_VERSION: ${{ matrix.python-version }}
+      run: |
+        .\Install.ps1 -d
+
+    - name: Build Windows installer with build_scripts\build_windows.ps1
+      env:
+        CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
+        WIN_CODE_SIGN_PASS: ${{ secrets.WIN_CODE_SIGN_PASS }}
+        HAS_SECRET: ${{ steps.check_secrets.outputs.HAS_SIGNING_SECRET }}
+      run: |
+        $env:path="C:\Program` Files` (x86)\Microsoft` Visual` Studio\2019\Enterprise\SDK\ScopeCppSDK\vc15\VC\bin\;$env:path"
+        $env:path="C:\Program` Files` (x86)\Windows` Kits\10\App` Certification` Kit;$env:path"
+        git -C .\chia-blockchain-gui status
+        .\venv\Scripts\Activate.ps1
+        cd .\build_scripts
+        .\build_windows.ps1
+
+    - name: Upload Windows exe's to artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: Windows-Exe
+        path: ${{ github.workspace }}\chia-blockchain-gui\Chia-win32-x64\
+
+    - name: Upload Installer to artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: chia-installers-windows-exe-intel
+        path: ${{ github.workspace }}\chia-blockchain-gui\release-builds\
+
+    - name: Install AWS CLI
+      if: steps.check_secrets.outputs.HAS_AWS_SECRET
+      run: |
+          msiexec.exe /i https://awscli.amazonaws.com/AWSCLIV2.msi
+
+    - name: Configure AWS Credentials
+      if: steps.check_secrets.outputs.HAS_AWS_SECRET
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.INSTALLER_UPLOAD_KEY }}
+        aws-secret-access-key: ${{ secrets.INSTALLER_UPLOAD_SECRET }}
+        aws-region: us-west-2
+
+    - name: Upload to s3
+      if: steps.check_secrets.outputs.HAS_AWS_SECRET
+      env:
+        CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
+      shell: bash
+      run: |
+        GIT_SHORT_HASH=$(echo "${GITHUB_SHA}" | cut -c1-8)
+        CHIA_DEV_BUILD=${CHIA_INSTALLER_VERSION}-$GIT_SHORT_HASH
+        echo ::set-output name=CHIA_DEV_BUILD::${CHIA_DEV_BUILD}
+        echo ${CHIA_DEV_BUILD}
+        pwd
+        aws s3 cp chia-blockchain-gui/release-builds/windows-installer/ChiaSetup-${CHIA_INSTALLER_VERSION}.exe s3://download.chia.net/dev/ChiaSetup-${CHIA_DEV_BUILD}.exe
+
+    - name: Create Checksums
+      env:
+        CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
+      run: |
+         certutil.exe -hashfile ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe SHA256 > ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe.sha256
+         ls ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\
+
+    - name: Install py3createtorrent
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        pip3 install py3createtorrent
+
+    - name: Create torrent
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        py3createtorrent -f -t udp://tracker.opentrackr.org:1337/announce ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe -o ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe.torrent --webseed https://download.chia.net/install/ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe
+        ls
+
+    - name: Upload Beta Installer
+      if: steps.check_secrets.outputs.HAS_AWS_SECRET && github.ref == 'refs/heads/main'
+      env:
+        CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
+      run: |
+        aws s3 cp ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe s3://download.chia.net/beta/ChiaSetup-latest-beta.exe
+        aws s3 cp ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe.sha256 s3://download.chia.net/beta/ChiaSetup-latest-beta.exe.sha256
+
+    - name: Upload Release Files
+      if: steps.check_secrets.outputs.HAS_AWS_SECRET && startsWith(github.ref, 'refs/tags/')
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.INSTALLER_UPLOAD_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.INSTALLER_UPLOAD_SECRET }}
+      run: |
+        aws s3 cp ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe s3://download.chia.net/install/
+        aws s3 cp ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe.sha256 s3://download.chia.net/install/
+        aws s3 cp ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe.torrent s3://download.chia.net/torrents/
+
+    - name: Get tag name
+      if: startsWith(github.ref, 'refs/tags/')
+      id: tag-name
+      run: |
+        echo "::set-output name=TAG_NAME::$(echo ${{ github.ref }} | cut -d'/' -f 3)"
+        echo "::set-output name=REPO_NAME::$(echo ${{ github.repository }} | cut -d'/' -f 2)"
+
+    - name: Mark installer complete
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        $headers = @{
+            Authorization="Bearer ${{ secrets.GLUE_ACCESS_TOKEN }}"
+        }
+        $data = @{
+            chia_ref='${{ steps.tag-name.outputs.TAG_NAME }}'
+        }
+        $json = $data | ConvertTo-Json
+        $response = Invoke-RestMethod '${{ secrets.GLUE_API_URL }}/api/v1/${{ steps.tag-name.outputs.REPO_NAME }}/${{ steps.tag-name.outputs.TAG_NAME }}/success/build-windows' -Method Post -Body $json -ContentType 'application/json' -Headers $headers

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -75,7 +75,6 @@ jobs:
         echo "::set-output name=HAS_SIGNING_SECRET::${HAS_SIGNING_SECRET}"
       env:
         SIGNING_SECRET: "${{ secrets.WIN_CODE_SIGN_CERT }}"
-        AWS_SECRET: "${{ secrets.INSTALLER_UPLOAD_KEY }}"
 
     - name: Decode code signing cert into an encrypted file
       if: steps.check_secrets.outputs.HAS_SIGNING_SECRET

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -82,7 +82,7 @@ jobs:
       uses: kitek/decode-base64-into-file-action@1.0
       with:
         encoded-value: ${{ secrets.WIN_CODE_SIGN_CERT }}
-        destination-file: .\chia-blockchain-gui\win_code_sign_cert.p12
+        destination-file: .\lotus-blockchain-gui\win_code_sign_cert.p12
 
     # Create our own venv outside of the git directory JUST for getting the ACTUAL version so that install can't break it
     - name: Get version number
@@ -149,7 +149,7 @@ jobs:
       run: |
         $env:path="C:\Program` Files` (x86)\Microsoft` Visual` Studio\2019\Enterprise\SDK\ScopeCppSDK\vc15\VC\bin\;$env:path"
         $env:path="C:\Program` Files` (x86)\Windows` Kits\10\App` Certification` Kit;$env:path"
-        git -C .\chia-blockchain-gui status
+        git -C .\lotus-blockchain-gui status
         .\venv\Scripts\Activate.ps1
         cd .\build_scripts
         .\build_windows.ps1
@@ -158,20 +158,20 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: Windows-Exe
-        path: ${{ github.workspace }}\chia-blockchain-gui\Chia-win32-x64\
+        path: ${{ github.workspace }}\lotus-blockchain-gui\Lotus-win32-x64\
 
     - name: Upload Installer to artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: chia-installers-windows-exe-intel
-        path: ${{ github.workspace }}\chia-blockchain-gui\release-builds\
+        name: lotus-installers-windows-exe-intel
+        path: ${{ github.workspace }}\lotus-blockchain-gui\release-builds\
 
     - name: Create Checksums
       env:
         CHIA_INSTALLER_VERSION: ${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}
       run: |
-         certutil.exe -hashfile ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe SHA256 > ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\ChiaSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe.sha256
-         ls ${{ github.workspace }}\chia-blockchain-gui\release-builds\windows-installer\
+         certutil.exe -hashfile ${{ github.workspace }}\lotus-blockchain-gui\release-builds\windows-installer\LotusSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe SHA256 > ${{ github.workspace }}\lotus-blockchain-gui\release-builds\windows-installer\LotusSetup-${{ steps.version_number.outputs.CHIA_INSTALLER_VERSION }}.exe.sha256
+         ls ${{ github.workspace }}\lotus-blockchain-gui\release-builds\windows-installer\
 
     - name: Get tag name
       if: startsWith(github.ref, 'refs/tags/')
@@ -187,7 +187,7 @@ jobs:
             Authorization="Bearer ${{ secrets.GLUE_ACCESS_TOKEN }}"
         }
         $data = @{
-            chia_ref='${{ steps.tag-name.outputs.TAG_NAME }}'
+            lotus_ref='${{ steps.tag-name.outputs.TAG_NAME }}'
         }
         $json = $data | ConvertTo-Json
         $response = Invoke-RestMethod '${{ secrets.GLUE_API_URL }}/api/v1/${{ steps.tag-name.outputs.REPO_NAME }}/${{ steps.tag-name.outputs.TAG_NAME }}/success/build-windows' -Method Post -Body $json -ContentType 'application/json' -Headers $headers

--- a/build_scripts/build_windows.ps1
+++ b/build_scripts/build_windows.ps1
@@ -1,4 +1,4 @@
-# $env:path should contain a path to editbin.exe and signtool.exe
+# $env:path should contain a path to editbin.exe
 
 $ErrorActionPreference = "Stop"
 
@@ -6,11 +6,11 @@ mkdir build_scripts\win_build
 
 git status
 
-if (-not (Test-Path env:LOTUS_INSTALLER_VERSION)) {
-  $env:LOTUS_INSTALLER_VERSION = '0.0.0'
-  Write-Output "WARNING: No environment variable LOTUS_INSTALLER_VERSION set. Using 0.0.0"
+if (-not (Test-Path env:LOTUS_VERSION)) {
+  $env:LOTUS_VERSION = '0.0.0'
+  Write-Output "WARNING: No environment variable LOTUS_VERSION set. Using 0.0.0"
 }
-Write-Output "Lotus Version is: $env:LOTUS_INSTALLER_VERSION"
+Write-Output "Lotus Version is: $env:LOTUS_VERSION"
 Write-Output "   ---"
 
 Write-Output "   ---"
@@ -19,100 +19,24 @@ Write-Output "   ---"
 $SPEC_FILE = (python -c 'import lotus; print(lotus.PYINSTALLER_SPEC_PATH)') -join "`n"
 pyinstaller --log-level INFO $SPEC_FILE
 
-Write-Output "   ---"
-Write-Output "Copy lotus executables to lotus-blockchain-gui\"
-Write-Output "   ---"
-Copy-Item "dist\daemon" -Destination "..\lotus-blockchain-gui\packages\gui\" -Recurse
-
-Write-Output "   ---"
-Write-Output "Setup npm packager"
-Write-Output "   ---"
-Set-Location -Path ".\npm_windows" -PassThru
-npm ci
-$Env:Path = $(npm bin) + ";" + $Env:Path
-Set-Location -Path "..\" -PassThru
-
-Set-Location -Path "..\lotus-blockchain-gui" -PassThru
-# We need the code sign cert in the gui subdirectory so we can actually sign the UI package
-If ($env:HAS_SECRET) {
-    Copy-Item "win_code_sign_cert.p12" -Destination "packages\gui\"
-}
-
 git status
 
-Write-Output "   ---"
-Write-Output "Prepare Electron packager"
-Write-Output "   ---"
-$Env:NODE_OPTIONS = "--max-old-space-size=3000"
-
-lerna clean -y
-npm ci
-# Audit fix does not currently work with Lerna. See https://github.com/lerna/lerna/issues/1663
-# npm audit fix
-
-git status
-
-Write-Output "   ---"
-Write-Output "Electron package Windows Installer"
-Write-Output "   ---"
-npm run build
-If ($LastExitCode -gt 0){
-    Throw "npm run build failed!"
-}
-
-# Change to the GUI directory
-Set-Location -Path "packages\gui" -PassThru
+# Change to the CLI directory
+Set-Location -Path "dist\daemon" -PassThru
 
 Write-Output "   ---"
 Write-Output "Increase the stack for lotus command for (lotus plots create) chiapos limitations"
 # editbin.exe needs to be in the path
-editbin.exe /STACK:8000000 daemon\lotus.exe
-Write-Output "   ---"
-
-$packageVersion = "$env:LOTUS_INSTALLER_VERSION"
-$packageName = "Lotus-$packageVersion"
-
-Write-Output "packageName is $packageName"
-
-Write-Output "   ---"
-Write-Output "fix version in package.json"
-choco install jq
-cp package.json package.json.orig
-jq --arg VER "$env:LOTUS_INSTALLER_VERSION" '.version=$VER' package.json > temp.json
-rm package.json
-mv temp.json package.json
-Write-Output "   ---"
-
-Write-Output "   ---"
-Write-Output "electron-packager"
-electron-packager . Lotus --asar.unpack="**\daemon\**" --overwrite --icon=.\src\assets\img\lotus.ico --app-version=$packageVersion
-Write-Output "   ---"
-
-Write-Output "   ---"
-Write-Output "node winstaller.js"
-node winstaller.js
+editbin.exe /STACK:8000000 lotus.exe
 Write-Output "   ---"
 
 git status
 
-If ($env:HAS_SECRET) {
-   Write-Output "   ---"
-   Write-Output "Add timestamp and verify signature"
-   Write-Output "   ---"
-   signtool.exe timestamp /v /t http://timestamp.comodoca.com/ .\release-builds\windows-installer\LotusSetup-$packageVersion.exe
-   signtool.exe verify /v /pa .\release-builds\windows-installer\LotusSetup-$packageVersion.exe
-   }   Else    {
-   Write-Output "Skipping timestamp and verify signatures - no authorization to install certificates"
-}
-
-git status
+Write-Output "   ---"
+Write-Output "Moving final binaries to expected location"
+Write-Output "   ---"
+Copy-Item "." -Destination "$env:GITHUB_WORKSPACE\Lotus-win32-x64" -Recurse
 
 Write-Output "   ---"
-Write-Output "Moving final installers to expected location"
-Write-Output "   ---"
-Copy-Item ".\Lotus-win32-x64" -Destination "$env:GITHUB_WORKSPACE\lotus-blockchain-gui\" -Recurse
-Copy-Item ".\release-builds" -Destination "$env:GITHUB_WORKSPACE\lotus-blockchain-gui\" -Recurse
-
-Write-Output "   ---"
-Write-Output "Windows Installer complete"
+Write-Output "Windows CLI Binaries complete"
 Write-Output "   ---"

--- a/build_scripts/build_windows.ps1
+++ b/build_scripts/build_windows.ps1
@@ -6,23 +6,23 @@ mkdir build_scripts\win_build
 
 git status
 
-if (-not (Test-Path env:CHIA_INSTALLER_VERSION)) {
-  $env:CHIA_INSTALLER_VERSION = '0.0.0'
-  Write-Output "WARNING: No environment variable CHIA_INSTALLER_VERSION set. Using 0.0.0"
+if (-not (Test-Path env:LOTUS_INSTALLER_VERSION)) {
+  $env:LOTUS_INSTALLER_VERSION = '0.0.0'
+  Write-Output "WARNING: No environment variable LOTUS_INSTALLER_VERSION set. Using 0.0.0"
 }
-Write-Output "Chia Version is: $env:CHIA_INSTALLER_VERSION"
+Write-Output "Lotus Version is: $env:LOTUS_INSTALLER_VERSION"
 Write-Output "   ---"
 
 Write-Output "   ---"
-Write-Output "Use pyinstaller to create chia .exe's"
+Write-Output "Use pyinstaller to create lotus .exe's"
 Write-Output "   ---"
-$SPEC_FILE = (python -c 'import chia; print(chia.PYINSTALLER_SPEC_PATH)') -join "`n"
+$SPEC_FILE = (python -c 'import lotus; print(lotus.PYINSTALLER_SPEC_PATH)') -join "`n"
 pyinstaller --log-level INFO $SPEC_FILE
 
 Write-Output "   ---"
-Write-Output "Copy chia executables to chia-blockchain-gui\"
+Write-Output "Copy lotus executables to lotus-blockchain-gui\"
 Write-Output "   ---"
-Copy-Item "dist\daemon" -Destination "..\chia-blockchain-gui\packages\gui\" -Recurse
+Copy-Item "dist\daemon" -Destination "..\lotus-blockchain-gui\packages\gui\" -Recurse
 
 Write-Output "   ---"
 Write-Output "Setup npm packager"
@@ -32,7 +32,7 @@ npm ci
 $Env:Path = $(npm bin) + ";" + $Env:Path
 Set-Location -Path "..\" -PassThru
 
-Set-Location -Path "..\chia-blockchain-gui" -PassThru
+Set-Location -Path "..\lotus-blockchain-gui" -PassThru
 # We need the code sign cert in the gui subdirectory so we can actually sign the UI package
 If ($env:HAS_SECRET) {
     Copy-Item "win_code_sign_cert.p12" -Destination "packages\gui\"
@@ -64,13 +64,13 @@ If ($LastExitCode -gt 0){
 Set-Location -Path "packages\gui" -PassThru
 
 Write-Output "   ---"
-Write-Output "Increase the stack for chia command for (chia plots create) chiapos limitations"
+Write-Output "Increase the stack for lotus command for (lotus plots create) chiapos limitations"
 # editbin.exe needs to be in the path
-editbin.exe /STACK:8000000 daemon\chia.exe
+editbin.exe /STACK:8000000 daemon\lotus.exe
 Write-Output "   ---"
 
-$packageVersion = "$env:CHIA_INSTALLER_VERSION"
-$packageName = "Chia-$packageVersion"
+$packageVersion = "$env:LOTUS_INSTALLER_VERSION"
+$packageName = "Lotus-$packageVersion"
 
 Write-Output "packageName is $packageName"
 
@@ -78,14 +78,14 @@ Write-Output "   ---"
 Write-Output "fix version in package.json"
 choco install jq
 cp package.json package.json.orig
-jq --arg VER "$env:CHIA_INSTALLER_VERSION" '.version=$VER' package.json > temp.json
+jq --arg VER "$env:LOTUS_INSTALLER_VERSION" '.version=$VER' package.json > temp.json
 rm package.json
 mv temp.json package.json
 Write-Output "   ---"
 
 Write-Output "   ---"
 Write-Output "electron-packager"
-electron-packager . Chia --asar.unpack="**\daemon\**" --overwrite --icon=.\src\assets\img\chia.ico --app-version=$packageVersion
+electron-packager . Lotus --asar.unpack="**\daemon\**" --overwrite --icon=.\src\assets\img\lotus.ico --app-version=$packageVersion
 Write-Output "   ---"
 
 Write-Output "   ---"
@@ -99,8 +99,8 @@ If ($env:HAS_SECRET) {
    Write-Output "   ---"
    Write-Output "Add timestamp and verify signature"
    Write-Output "   ---"
-   signtool.exe timestamp /v /t http://timestamp.comodoca.com/ .\release-builds\windows-installer\ChiaSetup-$packageVersion.exe
-   signtool.exe verify /v /pa .\release-builds\windows-installer\ChiaSetup-$packageVersion.exe
+   signtool.exe timestamp /v /t http://timestamp.comodoca.com/ .\release-builds\windows-installer\LotusSetup-$packageVersion.exe
+   signtool.exe verify /v /pa .\release-builds\windows-installer\LotusSetup-$packageVersion.exe
    }   Else    {
    Write-Output "Skipping timestamp and verify signatures - no authorization to install certificates"
 }
@@ -110,8 +110,8 @@ git status
 Write-Output "   ---"
 Write-Output "Moving final installers to expected location"
 Write-Output "   ---"
-Copy-Item ".\Chia-win32-x64" -Destination "$env:GITHUB_WORKSPACE\chia-blockchain-gui\" -Recurse
-Copy-Item ".\release-builds" -Destination "$env:GITHUB_WORKSPACE\chia-blockchain-gui\" -Recurse
+Copy-Item ".\Lotus-win32-x64" -Destination "$env:GITHUB_WORKSPACE\lotus-blockchain-gui\" -Recurse
+Copy-Item ".\release-builds" -Destination "$env:GITHUB_WORKSPACE\lotus-blockchain-gui\" -Recurse
 
 Write-Output "   ---"
 Write-Output "Windows Installer complete"

--- a/lotus/pyinstaller.spec
+++ b/lotus/pyinstaller.spec
@@ -1,0 +1,202 @@
+# -*- mode: python ; coding: utf-8 -*-
+import importlib
+import pathlib
+import platform
+import sysconfig
+
+from pkg_resources import get_distribution
+
+from PyInstaller.utils.hooks import collect_submodules, copy_metadata
+
+THIS_IS_WINDOWS = platform.system().lower().startswith("win")
+THIS_IS_MAC = platform.system().lower().startswith("darwin")
+
+ROOT = pathlib.Path(importlib.import_module("chia").__file__).absolute().parent.parent
+
+
+def solve_name_collision_problem(analysis):
+    """
+    There is a collision between the `chia` file name (which is the executable)
+    and the `chia` directory, which contains non-code resources like `english.txt`.
+    We move all the resources in the zipped area so there is no
+    need to create the `chia` directory, since the names collide.
+
+    Fetching data now requires going into a zip file, so it will be slower.
+    It's best if files that are used frequently are cached.
+
+    A sample large compressible file (1 MB of `/dev/zero`), seems to be
+    about eight times slower.
+
+    Note that this hack isn't documented, but seems to work.
+    """
+
+    zipped = []
+    datas = []
+    for data in analysis.datas:
+        if str(data[0]).startswith("chia/"):
+            zipped.append(data)
+        else:
+            datas.append(data)
+
+    # items in this field are included in the binary
+    analysis.zipped_data = zipped
+
+    # these items will be dropped in the root folder uncompressed
+    analysis.datas = datas
+
+
+keyring_imports = collect_submodules("keyring.backends")
+
+# keyring uses entrypoints to read keyring.backends from metadata file entry_points.txt.
+keyring_datas = copy_metadata("keyring")[0]
+
+version_data = copy_metadata(get_distribution("chia-blockchain"))[0]
+
+block_cipher = None
+
+SERVERS = [
+    "wallet",
+    "full_node",
+    "harvester",
+    "farmer",
+    "introducer",
+    "timelord",
+]
+
+# TODO: collapse all these entry points into one `chia_exec` entrypoint that accepts the server as a parameter
+
+entry_points = ["chia.cmds.chia"] + [f"chia.server.start_{s}" for s in SERVERS]
+
+hiddenimports = []
+hiddenimports.extend(entry_points)
+hiddenimports.extend(keyring_imports)
+
+binaries = [
+    (
+        f"{ROOT}/madmax/chia_plot",
+        "madmax"
+    ),
+    (
+        f"{ROOT}/madmax/chia_plot_k34",
+        "madmax"
+    )
+]
+
+if not THIS_IS_MAC:
+    binaries.extend([
+        (
+            f"{ROOT}/bladebit/bladebit",
+            "bladebit"
+        )
+    ])
+
+if THIS_IS_WINDOWS:
+    hiddenimports.extend(["win32timezone", "win32cred", "pywintypes", "win32ctypes.pywin32"])
+
+# this probably isn't necessary
+if THIS_IS_WINDOWS:
+    entry_points.extend(["aiohttp", "chia.util.bip39"])
+
+if THIS_IS_WINDOWS:
+    chia_mod = importlib.import_module("chia")
+    dll_paths = pathlib.Path(sysconfig.get_path("platlib")) / "*.dll"
+
+    binaries = [
+        (
+            dll_paths,
+            ".",
+        ),
+        (
+            "C:\\Windows\\System32\\msvcp140.dll",
+            ".",
+        ),
+        (
+            "C:\\Windows\\System32\\vcruntime140_1.dll",
+            ".",
+        ),
+        (
+            f"{ROOT}\\madmax\\chia_plot.exe",
+            "madmax"
+        ),
+        (
+            f"{ROOT}\\madmax\\chia_plot_k34.exe",
+            "madmax"
+        ),
+        (
+            f"{ROOT}\\bladebit\\bladebit.exe",
+            "bladebit"
+        ),
+    ]
+
+
+datas = []
+
+datas.append((f"{ROOT}/chia/util/english.txt", "chia/util"))
+datas.append((f"{ROOT}/chia/util/initial-config.yaml", "chia/util"))
+datas.append((f"{ROOT}/chia/wallet/puzzles/*.hex", "chia/wallet/puzzles"))
+datas.append((f"{ROOT}/chia/ssl/*", "chia/ssl"))
+datas.append((f"{ROOT}/mozilla-ca/*", "mozilla-ca"))
+datas.append(version_data)
+
+pathex = []
+
+
+def add_binary(name, path_to_script, collect_args):
+    analysis = Analysis(
+        [path_to_script],
+        pathex=pathex,
+        binaries=binaries,
+        datas=datas,
+        hiddenimports=hiddenimports,
+        hookspath=[],
+        runtime_hooks=[],
+        excludes=[],
+        win_no_prefer_redirects=False,
+        win_private_assemblies=False,
+        cipher=block_cipher,
+        noarchive=False,
+    )
+
+    solve_name_collision_problem(analysis)
+
+    binary_pyz = PYZ(analysis.pure, analysis.zipped_data, cipher=block_cipher)
+
+    binary_exe = EXE(
+        binary_pyz,
+        analysis.scripts,
+        [],
+        exclude_binaries=True,
+        name=name,
+        debug=False,
+        bootloader_ignore_signals=False,
+        strip=False,
+    )
+
+    collect_args.extend(
+        [
+            binary_exe,
+            analysis.binaries,
+            analysis.zipfiles,
+            analysis.datas,
+        ]
+    )
+
+
+COLLECT_ARGS = []
+
+add_binary("chia", f"{ROOT}/chia/cmds/chia.py", COLLECT_ARGS)
+add_binary("daemon", f"{ROOT}/chia/daemon/server.py", COLLECT_ARGS)
+
+for server in SERVERS:
+    add_binary(f"start_{server}", f"{ROOT}/chia/server/start_{server}.py", COLLECT_ARGS)
+
+add_binary("start_crawler", f"{ROOT}/chia/seeder/start_crawler.py", COLLECT_ARGS)
+add_binary("start_seeder", f"{ROOT}/chia/seeder/dns_server.py", COLLECT_ARGS)
+
+COLLECT_KWARGS = dict(
+    strip=False,
+    upx_exclude=[],
+    name="daemon",
+)
+
+coll = COLLECT(*COLLECT_ARGS, **COLLECT_KWARGS)

--- a/lotus/pyinstaller.spec
+++ b/lotus/pyinstaller.spec
@@ -11,15 +11,15 @@ from PyInstaller.utils.hooks import collect_submodules, copy_metadata
 THIS_IS_WINDOWS = platform.system().lower().startswith("win")
 THIS_IS_MAC = platform.system().lower().startswith("darwin")
 
-ROOT = pathlib.Path(importlib.import_module("chia").__file__).absolute().parent.parent
+ROOT = pathlib.Path(importlib.import_module("lotus").__file__).absolute().parent.parent
 
 
 def solve_name_collision_problem(analysis):
     """
-    There is a collision between the `chia` file name (which is the executable)
-    and the `chia` directory, which contains non-code resources like `english.txt`.
+    There is a collision between the `lotus` file name (which is the executable)
+    and the `lotus` directory, which contains non-code resources like `english.txt`.
     We move all the resources in the zipped area so there is no
-    need to create the `chia` directory, since the names collide.
+    need to create the `lotus` directory, since the names collide.
 
     Fetching data now requires going into a zip file, so it will be slower.
     It's best if files that are used frequently are cached.
@@ -33,7 +33,7 @@ def solve_name_collision_problem(analysis):
     zipped = []
     datas = []
     for data in analysis.datas:
-        if str(data[0]).startswith("chia/"):
+        if str(data[0]).startswith("lotus/"):
             zipped.append(data)
         else:
             datas.append(data)
@@ -50,7 +50,7 @@ keyring_imports = collect_submodules("keyring.backends")
 # keyring uses entrypoints to read keyring.backends from metadata file entry_points.txt.
 keyring_datas = copy_metadata("keyring")[0]
 
-version_data = copy_metadata(get_distribution("chia-blockchain"))[0]
+version_data = copy_metadata(get_distribution("lotus-blockchain"))[0]
 
 block_cipher = None
 
@@ -63,9 +63,9 @@ SERVERS = [
     "timelord",
 ]
 
-# TODO: collapse all these entry points into one `chia_exec` entrypoint that accepts the server as a parameter
+# TODO: collapse all these entry points into one `lotus_exec` entrypoint that accepts the server as a parameter
 
-entry_points = ["chia.cmds.chia"] + [f"chia.server.start_{s}" for s in SERVERS]
+entry_points = ["lotus.cmds.lotus"] + [f"lotus.server.start_{s}" for s in SERVERS]
 
 hiddenimports = []
 hiddenimports.extend(entry_points)
@@ -95,10 +95,10 @@ if THIS_IS_WINDOWS:
 
 # this probably isn't necessary
 if THIS_IS_WINDOWS:
-    entry_points.extend(["aiohttp", "chia.util.bip39"])
+    entry_points.extend(["aiohttp", "lotus.util.bip39"])
 
 if THIS_IS_WINDOWS:
-    chia_mod = importlib.import_module("chia")
+    lotus_mod = importlib.import_module("lotus")
     dll_paths = pathlib.Path(sysconfig.get_path("platlib")) / "*.dll"
 
     binaries = [
@@ -131,10 +131,10 @@ if THIS_IS_WINDOWS:
 
 datas = []
 
-datas.append((f"{ROOT}/chia/util/english.txt", "chia/util"))
-datas.append((f"{ROOT}/chia/util/initial-config.yaml", "chia/util"))
-datas.append((f"{ROOT}/chia/wallet/puzzles/*.hex", "chia/wallet/puzzles"))
-datas.append((f"{ROOT}/chia/ssl/*", "chia/ssl"))
+datas.append((f"{ROOT}/lotus/util/english.txt", "lotus/util"))
+datas.append((f"{ROOT}/lotus/util/initial-config.yaml", "lotus/util"))
+datas.append((f"{ROOT}/lotus/wallet/puzzles/*.hex", "lotus/wallet/puzzles"))
+datas.append((f"{ROOT}/lotus/ssl/*", "lotus/ssl"))
 datas.append((f"{ROOT}/mozilla-ca/*", "mozilla-ca"))
 datas.append(version_data)
 
@@ -184,14 +184,14 @@ def add_binary(name, path_to_script, collect_args):
 
 COLLECT_ARGS = []
 
-add_binary("chia", f"{ROOT}/chia/cmds/chia.py", COLLECT_ARGS)
-add_binary("daemon", f"{ROOT}/chia/daemon/server.py", COLLECT_ARGS)
+add_binary("lotus", f"{ROOT}/lotus/cmds/lotus.py", COLLECT_ARGS)
+add_binary("daemon", f"{ROOT}/lotus/daemon/server.py", COLLECT_ARGS)
 
 for server in SERVERS:
-    add_binary(f"start_{server}", f"{ROOT}/chia/server/start_{server}.py", COLLECT_ARGS)
+    add_binary(f"start_{server}", f"{ROOT}/lotus/server/start_{server}.py", COLLECT_ARGS)
 
-add_binary("start_crawler", f"{ROOT}/chia/seeder/start_crawler.py", COLLECT_ARGS)
-add_binary("start_seeder", f"{ROOT}/chia/seeder/dns_server.py", COLLECT_ARGS)
+add_binary("start_crawler", f"{ROOT}/lotus/seeder/start_crawler.py", COLLECT_ARGS)
+add_binary("start_seeder", f"{ROOT}/lotus/seeder/dns_server.py", COLLECT_ARGS)
 
 COLLECT_KWARGS = dict(
     strip=False,


### PR DESCRIPTION
This PR will allow for producing Windows EXEs for Lotus from the Actions tab, rather than having to clone and install on source, which is difficult on Windows due to the lack of instructions for it. Note that since Lotus doesn't have a GUI, the build script only produces the backend and can only be controlled through CLI or RPC.